### PR TITLE
Add AMD defition in core JavaScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### HEAD
+
+* Add AMD defition in core JavaScript
+
 ### 0.3.1 (January 23rd, 2014)
 
 * Enabled polyfill to initialize after load when being fetched asynchronously

--- a/src/polyfill.object-fit.core.js
+++ b/src/polyfill.object-fit.core.js
@@ -375,7 +375,21 @@
 		}
 	};
 
-	// Export into global space
-	global.objectFit = objectFit;
+	/*
+	 * AMD, module loader, global registration
+	 */
+
+	// Expose modal for loaders that implement the Node module pattern.
+	if (typeof module === 'object' && module && typeof module.exports === 'object') {
+		module.exports = objectFit;
+
+	// Register as an AMD module
+	} else if (typeof define === 'function' && define.amd) {
+		define([], function () { return objectFit; });
+
+	// Export CSSModal into global space
+	} else if (typeof global === 'object' && typeof global.document === 'object') {
+		global.objectFit = objectFit;
+	}
 
 }(window));


### PR DESCRIPTION
This commit adds support for AMD libraries like RequireJS and concepts as CommonJS. If these concepts are not used within your project the polyfill's object is exposed to the global scope.

Also fixes of inconstant white space.
