### PR TITLE
Fix empty values in CSSProperties (#5)

### DIFF
--- a/dist/polyfill.object-fit.js
+++ b/dist/polyfill.object-fit.js
@@ -390,12 +390,15 @@
 			switch (property) {
 				default:
 					value = replacedElementDefaultStyles[property];
+
 					if (objectFit._debug && window.console && value !== '') {
 						console.log(property + ': ' + value);
 					}
-					replacedElement.style[property] = value;
+					if (value !== '') {
+						replacedElement.style['property'] = value;
+					}
 				break;
-				
+
 				case 'length':
 				case 'parentRule':
 				break;


### PR DESCRIPTION
This’d fix the current issues. Though I’m not entirely sure that the value should ever be '' I added this if switch. What do you think @Schepp, is this a workaround / tmp fix we should deploy so FF users get the object-fit behavior?
