### PR TITLE
remove bower dependance for a npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,14 +13,13 @@
   },
   "license": "MIT",
   "scripts": {
-    "postinstall": "bower install"
+    "postinstall": ""
   },
   "engines": {
     "node": ">=0.10"
   },
   "dependencies": {},
   "devDependencies": {
-    "bower": "~1.3.9",
     "grunt": "0.4.x",
     "grunt-contrib-concat": "~0.5.0",
     "grunt-contrib-jshint": "0.10.0",


### PR DESCRIPTION
hi!
I am working for a front end project without bower, i would like to adapt your project to fit (get it?) to my needs.
The bower part should still work, since bower works with bowerrc and bower.json files.
Thanks !
