### PR TITLE
Typo, whitespace & updated main array

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -19,7 +19,7 @@ module.exports = function (grunt) {
 				jshintrc: '.jshintrc'
 			}
 		},
-		
+
 		concat: {
 			csss: {
 				src: 'src/polyfill.object-fit.css',

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ or set up via npm
 
 	$ npm install --save object-fit
 
-The `--safe` flag is used to store the package dependency in the package.json so it can be automatically fetched next time using `npm install`. Use `--save-dev` to use it only as development dependency (but only do if you are sure you know what you do).
+The `--save` flag is used to store the package dependency in the package.json so it can be automatically fetched next time using `npm install`. Use `--save-dev` to use it only as development dependency (but only do if you are sure you know what you do).
 
 Or set up manually by grabbing the [download from GitHub](https://github.com/anselmh/object-fit/releases).
 Then include the CSS file [`polyfill.object-fit.css`](https://github.com/anselmh/object-fit/blob/master/dist/polyfill.object-fit.css) in your HTML `<head>`, the JavaScript file [`polyfill.object-fit.min.js`](https://github.com/anselmh/object-fit/blob/master/dist/polyfill.object-fit.min.js) at the bottom of your HTML `<body>`. Right behind the JavaScript file reference you now need to call the polyfill:

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,10 @@
 {
   "name": "object-fit",
   "version": "0.3.6",
-  "main": "dist/polyfill.object-fit.js",
+  "main": [
+    "dist/polyfill.object-fit.js",
+    "dist/polyfill.object-fit.css"
+  ],
   "ignore": [
     "**/.*",
     "node_modules",


### PR DESCRIPTION
* Removed unnecessary white space in Gruntfile.js.
* Updated the main array to include the CSS file. This way Grunt's
Wiredep task inject the CSS file.
* Typo : `safe` flag changed to `save`.